### PR TITLE
Fixed issue where queueCallback was called before task was complete

### DIFF
--- a/index.js
+++ b/index.js
@@ -68,12 +68,12 @@ module.exports = function(options, files, taskCallback) {
 
             try {
               pack.addFile(src, dest);
-              queueCallback(null, filePair.src || filePair);
             } catch (ex) {
               throw ex;
               queueCallback(ex);
             }
           });
+          queueCallback(null, filePair.src || filePair);
           streamCallback();
         }));
     });


### PR DESCRIPTION
When running nugetpack with a source of "folder/*_/_" the queueCallback would be called as soon as the first file had processed, meaning that only that first type would be added to the [Content_Types].xml file.

This should fix the issue by making sure the queueCallback is not called until after all files have been processed.
