### PR TITLE
Upgrade gulp to v4 with latest minimatch that fixes regex DOS; remove deprecated gulp-util.

### DIFF
--- a/gulpfile.js
+++ b/gulpfile.js
@@ -3,7 +3,7 @@
 var gulp = require('gulp');
 var nugetpack = require('./index');
 
-gulp.task('package', function(callback) {
+gulp.task('test', function(callback) {
   var pkg = require('./package.json');
 
   nugetpack({
@@ -35,5 +35,3 @@ gulp.task('package', function(callback) {
 
     callback);
 });
-
-gulp.task('test', ['package'])

--- a/index.js
+++ b/index.js
@@ -4,7 +4,7 @@ var fs = require('fs');
 var path = require('path');
 var gulp = require('gulp');
 var queue = require('queue-async');
-var gutil = require('gulp-util');
+var PluginError = require('plugin-error');
 var through = require('through2');
 var Package = require('grunt-nuget-pack/lib/Package');
 
@@ -90,7 +90,7 @@ module.exports = function(options, files, taskCallback) {
       pack.saveAs(packageFilePath, taskCallback);
       gutil.log(gutil.colors.green("Created nupkg file:"), gutil.colors.white(packageFilePath));
     } catch (ex) {
-      throw new gutil.PluginError({
+      throw new PluginError({
         plugin: 'nugetpack',
         message: ex.message
       });

--- a/index.js
+++ b/index.js
@@ -4,8 +4,10 @@ var fs = require('fs');
 var path = require('path');
 var gulp = require('gulp');
 var queue = require('queue-async');
-var gutil = require('gulp-util');
+var PluginError = require('plugin-error');
 var through = require('through2');
+var log = require('fancy-log');
+var colors = require('ansi-colors');
 var Package = require('grunt-nuget-pack/lib/Package');
 
 var NUGETPACK_EXT = "nupkg";
@@ -14,7 +16,7 @@ module.exports = function(options, files, taskCallback) {
   var baseDir, pack;
 
   if (typeof options != "object") {
-    throw new gutil.PluginError({
+    throw new PluginError({
       plugin: 'nugetpack',
       message: "Required meta information not specified."
     });
@@ -47,7 +49,7 @@ module.exports = function(options, files, taskCallback) {
             if (!dest) {
               if (path.resolve(src)
                 .indexOf(path.resolve(baseDir)) !== 0) {
-                throw new gutil.PluginError({
+                throw new PluginError({
                   plugin: 'nugetpack',
                   message: "Path for file: " + src +
                     " isn't within the baseDir: " +
@@ -88,9 +90,9 @@ module.exports = function(options, files, taskCallback) {
 
     try {
       pack.saveAs(packageFilePath, taskCallback);
-      gutil.log(gutil.colors.green("Created nupkg file:"), gutil.colors.white(packageFilePath));
+      log(colors.green("Created nupkg file:"), colors.white(packageFilePath));
     } catch (ex) {
-      throw new gutil.PluginError({
+      throw new PluginError({
         plugin: 'nugetpack',
         message: ex.message
       });

--- a/package.json
+++ b/package.json
@@ -25,8 +25,8 @@
   "devDependencies": {},
   "dependencies": {
     "grunt-nuget-pack": "0.0.6",
-    "gulp": "^3.8.11",
-    "gulp-util": "^3.0.4",
+    "gulp": "^4.0.0",
+    "plugin-error": "^1.0.1",
     "queue-async": "^1.0.7",
     "through2": "^0.6.5"
   }

--- a/package.json
+++ b/package.json
@@ -22,11 +22,14 @@
     "url": "https://github.com/w8r/gulp-nuget-pack/issues"
   },
   "homepage": "https://github.com/w8r/gulp-nuget-pack#readme",
-  "devDependencies": {},
+  "devDependencies": {
+    "ansi-colors": "^3.1.0",
+    "fancy-log": "^1.3.2"
+  },
   "dependencies": {
     "grunt-nuget-pack": "0.0.6",
-    "gulp": "^3.8.11",
-    "gulp-util": "^3.0.4",
+    "gulp": "^4.0.0",
+    "plugin-error": "^1.0.1",
     "queue-async": "^1.0.7",
     "through2": "^0.6.5"
   }

--- a/package.json
+++ b/package.json
@@ -22,11 +22,10 @@
     "url": "https://github.com/w8r/gulp-nuget-pack/issues"
   },
   "homepage": "https://github.com/w8r/gulp-nuget-pack#readme",
-  "devDependencies": {
-    "ansi-colors": "^3.1.0",
-    "fancy-log": "^1.3.2"
-  },
+  "devDependencies": {},
   "dependencies": {
+    "ansi-colors": "^3.1.0",
+    "fancy-log": "^1.3.2",
     "grunt-nuget-pack": "0.0.6",
     "gulp": "^4.0.0",
     "plugin-error": "^1.0.1",


### PR DESCRIPTION
More on the issue:
https://www.npmjs.com/advisories/118

on gulp-util deprecation:
https://github.com/SC5/sc5-styleguide/issues/1127